### PR TITLE
Fix: error referring to wrong plugin name

### DIFF
--- a/src/main/groovy/com/palantir/gradle/shadowjar/ShadowJarPlugin.java
+++ b/src/main/groovy/com/palantir/gradle/shadowjar/ShadowJarPlugin.java
@@ -69,8 +69,8 @@ public class ShadowJarPlugin implements Plugin<Project> {
         }
 
         if (!project.getRootProject().getPlugins().hasPlugin("com.palantir.consistent-versions")) {
-            throw new IllegalStateException("You must apply com.palantir.consistent-versions to use the "
-                    + "com.palantir.shadow-jar plugin");
+            throw new IllegalStateException(
+                    "You must apply com.palantir.consistent-versions to use the com.palantir.shadow-jar plugin");
         }
 
         project.getPluginManager().apply(JavaPlugin.class);

--- a/src/main/groovy/com/palantir/gradle/shadowjar/ShadowJarPlugin.java
+++ b/src/main/groovy/com/palantir/gradle/shadowjar/ShadowJarPlugin.java
@@ -65,12 +65,12 @@ public class ShadowJarPlugin implements Plugin<Project> {
     public final void apply(Project project) {
         if (GradleVersion.current().compareTo(GradleVersion.version("6.0")) < 0) {
             throw new IllegalStateException(
-                    "You must be using Gradle 6 or above to use the com.palantir.publish-shadow-jar plugin");
+                    "You must be using Gradle 6 or above to use the com.palantir.shadow-jar plugin");
         }
 
         if (!project.getRootProject().getPlugins().hasPlugin("com.palantir.consistent-versions")) {
             throw new IllegalStateException("You must apply com.palantir.consistent-versions to use the "
-                    + "com.palantir.publish-shadow-jar plugin");
+                    + "com.palantir.shadow-jar plugin");
         }
 
         project.getPluginManager().apply(JavaPlugin.class);


### PR DESCRIPTION
## Before this PR

Error mentioned `com.palantir.publish-shadow-jar`.

## After this PR
==COMMIT_MSG==
Precondition error messages now mention the correct plugin id.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
