### PR TITLE
Support multi-release jars like `one.util:streamex`

### DIFF
--- a/src/main/groovy/com/palantir/gradle/shadowjar/ShadowJarConfigurationTask.java
+++ b/src/main/groovy/com/palantir/gradle/shadowjar/ShadowJarConfigurationTask.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.shadowjar;
 
+import com.github.jengelman.gradle.plugins.shadow.relocation.CacheableRelocator;
 import com.github.jengelman.gradle.plugins.shadow.relocation.RelocateClassContext;
 import com.github.jengelman.gradle.plugins.shadow.relocation.RelocatePathContext;
 import com.github.jengelman.gradle.plugins.shadow.relocation.SimpleRelocator;
@@ -132,7 +133,7 @@ public abstract class ShadowJarConfigurationTask extends DefaultTask {
         }
     }
 
-    @SuppressWarnings("BanSystemOut")
+    @CacheableRelocator
     private static final class JarFilesRelocator extends SimpleRelocator {
         private final Set<String> relocatable;
 

--- a/src/main/groovy/com/palantir/gradle/shadowjar/ShadowJarConfigurationTask.java
+++ b/src/main/groovy/com/palantir/gradle/shadowjar/ShadowJarConfigurationTask.java
@@ -25,7 +25,6 @@ import com.github.jengelman.gradle.plugins.shadow.transformers.ManifestAppenderT
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -129,10 +128,7 @@ public abstract class ShadowJarConfigurationTask extends DefaultTask {
                     // JEP 238 requires this manifest entry
                     transformer.append("Multi-Release", true);
                 });
-            } catch (InstantiationException
-                    | IllegalAccessException
-                    | NoSuchMethodException
-                    | InvocationTargetException e) {
+            } catch (ReflectiveOperationException e) {
                 throw new RuntimeException("Unable to construct ManifestAppenderTransformer", e);
             }
         }

--- a/src/main/groovy/com/palantir/gradle/shadowjar/ShadowJarConfigurationTask.java
+++ b/src/main/groovy/com/palantir/gradle/shadowjar/ShadowJarConfigurationTask.java
@@ -97,7 +97,7 @@ public abstract class ShadowJarConfigurationTask extends DefaultTask {
                         return Collections.list(jarFile.entries()).stream()
                                 .filter(entry -> !entry.isDirectory())
                                 .map(ZipEntry::getName)
-                                // .peek(path -> getLogger().lifecycle("Jar {} contains entry {}", jar.getName(), path))
+                                .peek(path -> log.debug("Jar '{}' contains entry '{}'", jar.getName(), path))
                                 .peek(path -> Preconditions.checkState(
                                         !path.startsWith("/"), "Unexpected absolute path '%s' in jar '%s'", path, jar))
                                 .collect(Collectors.toList())

--- a/src/main/groovy/com/palantir/gradle/shadowjar/ShadowJarPlugin.java
+++ b/src/main/groovy/com/palantir/gradle/shadowjar/ShadowJarPlugin.java
@@ -238,7 +238,9 @@ public class ShadowJarPlugin implements Plugin<Project> {
         shadowJarProvider.configure(shadowJar -> {
             // Enable archive with more than 2^16 files
             shadowJar.setZip64(true);
-            // This seems like a good default for every java project
+
+            // Multiple jars might have an entry in META-INF/services for the same interface, so we merge them.
+            // https://imperceptiblethoughts.com/shadow/configuration/merging/#merging-service-descriptor-files
             shadowJar.mergeServiceFiles();
         });
     }

--- a/src/test/groovy/com/palantir/gradle/shadowjar/ShadowJarPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/shadowjar/ShadowJarPluginIntegrationSpec.groovy
@@ -180,6 +180,13 @@ class ShadowJarPluginIntegrationSpec extends IntegrationSpec {
                 'META-INF/versions/9/shadow/com/palantir/bar_baz_quux/asd_fgh/one/util/streamex/VerSpec.class')
         assert jarEntryNames.contains(
                 'META-INF/versions/9/shadow/com/palantir/bar_baz_quux/asd_fgh/one/util/streamex/Java9Specific.class')
+        assert !jarEntryNames.contains(
+                'META-INF/versions/9/one/util/streamex/VerSpec.class')
+        assert !jarEntryNames.contains(
+                'META-INF/versions/9/one/util/streamex/Java9Specific.class')
+
+        assert shadowJarFile().getManifest().getMainAttributes().getValue("Multi-Release") == "true" :
+                "The jar manifest must include 'Multi-Release: true'"
     }
 
     def 'should shade known logging implementations iff it is placed in shadeTransitively directly'() {

--- a/src/test/groovy/com/palantir/gradle/shadowjar/ShadowJarPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/shadowjar/ShadowJarPluginIntegrationSpec.groovy
@@ -172,20 +172,14 @@ class ShadowJarPluginIntegrationSpec extends IntegrationSpec {
         writeHelloWorld()
         runTasksAndCheckSuccess('extractForAssertions')
 
-        JarFile shadowJar = shadowJarFile()
-        def jarEntryNames = shadowJar.stream().map({it.name}).collect(Collectors.toSet())
+        def jarEntryNames = shadowJarFile().stream()
+                .map({it.name})
+                .collect(Collectors.toCollection({new LinkedHashSet()}))
 
-        assert jarEntryNames.contains(
-                'shadow/com/palantir/bar_baz_quux/asd_fgh/one/util/streamex/Joining$Accumulator.class')
         assert jarEntryNames.contains(
                 'META-INF/versions/9/shadow/com/palantir/bar_baz_quux/asd_fgh/one/util/streamex/VerSpec.class')
-
-        // this is BAD, just capturing current behaviour (https://github.com/palantir/gradle-shadow-jar/issues/65)
-        assert jarEntryNames.contains('META-INF/versions/9/one/util/streamex/Java9Specific.class')
-
-        // this also seems wonky??
-        file("build/extractForAssertions/shadow/com/palantir/bar_baz_quux/asd_fgh/META-INF/MANIFEST.MF").text ==
-                "Manifest-Version: 1.0\r\n\r\n"
+        assert jarEntryNames.contains(
+                'META-INF/versions/9/shadow/com/palantir/bar_baz_quux/asd_fgh/one/util/streamex/Java9Specific.class')
     }
 
     def 'should shade known logging implementations iff it is placed in shadeTransitively directly'() {

--- a/src/test/groovy/com/palantir/gradle/shadowjar/ShadowJarPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/shadowjar/ShadowJarPluginIntegrationSpec.groovy
@@ -150,7 +150,9 @@ class ShadowJarPluginIntegrationSpec extends IntegrationSpec {
         assert !jarEntryNames.contains(relocatedClass('org/slf4j/impl/Log4jLoggerFactory.class'))
     }
 
-    def 'should support multi-release jars (MRJARS, https://www.baeldung.com/java-multi-release-jar)'() {
+    def 'should support multi-release jars'() {
+        // https://www.baeldung.com/java-multi-release-jar
+
         when:
         buildFile << """
             repositories {
@@ -185,8 +187,9 @@ class ShadowJarPluginIntegrationSpec extends IntegrationSpec {
         assert !jarEntryNames.contains(
                 'META-INF/versions/9/one/util/streamex/Java9Specific.class')
 
-        assert shadowJarFile().getManifest().getMainAttributes().getValue("Multi-Release") == "true" :
-                "The jar manifest must include 'Multi-Release: true'"
+        assert shadowJarFile().isMultiRelease() ?:
+                "The jar manifest must include 'Multi-Release: true', but was '" +
+                        file("build/extractForAssertions/META-INF/MANIFEST.MF").text + "'"
     }
 
     def 'should shade known logging implementations iff it is placed in shadeTransitively directly'() {
@@ -359,8 +362,7 @@ class ShadowJarPluginIntegrationSpec extends IntegrationSpec {
 
     @CompileStatic
     private JarFile shadowJarFile() {
-        return new JarFile(
-                new File(projectDir, "${MAVEN_ROOT}/com/palantir/bar-baz_quux/asd-fgh/2/asd-fgh-2.jar"))
+        return new JarFile(file("${MAVEN_ROOT}/com/palantir/bar-baz_quux/asd-fgh/2/asd-fgh-2.jar"))
     }
 
     @CompileStatic


### PR DESCRIPTION
## Before this PR

We've had a lot of reports in `#dev-foundry-infra` recently about people seeing one.util:streamex appearing in their baseline-class-uniqueness.lock files. (See relevant issue which this PR will fix https://github.com/palantir/gradle-shadow-jar/issues/65)

https://www.baeldung.com/java-multi-release-jar

I don't think anything has actually broken _yet_ because of this, but if a shadowed jar tries to call one of these improperly relocated classes I think bad things will happen.

## After this PR
==COMMIT_MSG==
Support Multi-Release JARs (https://openjdk.java.net/jeps/238) like `one.util:streamex`.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
