### PR TITLE
Support resources with leading slash (MSHADE-119)

### DIFF
--- a/src/test/groovy/com/palantir/gradle/shadowjar/ShadowJarPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/shadowjar/ShadowJarPluginIntegrationSpec.groovy
@@ -379,8 +379,9 @@ class ShadowJarPluginIntegrationSpec extends IntegrationSpec {
        
         public final class Foo {
             public static void main(String... args) throws IOException {
-                System.out.println("Hello, world");
-                URL resource = Foo.class.getResource("/whatever.txt");
+                String path = "/whatever.txt";
+                System.out.println("Attempting to load resource: " + path);
+                URL resource = Foo.class.getResource(path);
                 resource.openStream().transferTo(System.out);
             }
         }
@@ -391,6 +392,11 @@ class ShadowJarPluginIntegrationSpec extends IntegrationSpec {
 
         then:
         ExecutionResult success = runTasksAndCheckSuccess('runApp', '-qs')
+        success.standardOutput.contains("""\
+        Attempting to load resource: /shadow/com/palantir/bar_baz_quux/asd_fgh/whatever.txt
+        1. RESOURCE LINE ONE
+        2. RESOURCE LINE TWO
+        """.stripIndent())
     }
 
     @CompileStatic


### PR DESCRIPTION
## Before this PR

In overriding some methods from the upstream SimpleRelocator, it seems we didn't copy over the logic to handle this edge case.

fixes https://github.com/palantir/gradle-shadow-jar/issues/69

## After this PR
==COMMIT_MSG==
Support resources with leading slash (MSHADE-119)
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
