### PR TITLE
Ensure jar task is triggered to pick up manifest attributes

### DIFF
--- a/changelog/@unreleased/pr-74.v2.yml
+++ b/changelog/@unreleased/pr-74.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: '`shadowJar` now depends on the `jar` task in order to trigger tasks
+    like `configureProductDependencies` from `com.palantir.sls-recommended-dependencies`
+    which modify the `jar` manifest, so that these `manifest` changes are inherited
+    by default in `shadowJar`.'
+  links:
+  - https://github.com/palantir/gradle-shadow-jar/pull/74

--- a/src/main/groovy/com/palantir/gradle/shadowjar/ShadowJarPlugin.java
+++ b/src/main/groovy/com/palantir/gradle/shadowjar/ShadowJarPlugin.java
@@ -86,6 +86,8 @@ public class ShadowJarPlugin implements Plugin<Project> {
         configureShadowJarTaskWithGoodDefaults(shadowJarProvider);
 
         ensureShadowJarIsOnlyArtifactOnJavaConfigurations(project, shadowJarProvider);
+
+        dependOnJarTaskInOrderToTriggerTasksAddingManifestAttributes(project, shadowJarProvider);
     }
 
     private void setupShadowJarToShadeTheCorrectDependencies(
@@ -245,7 +247,7 @@ public class ShadowJarPlugin implements Plugin<Project> {
         });
     }
 
-    private void ensureShadowJarIsOnlyArtifactOnJavaConfigurations(
+    private static void ensureShadowJarIsOnlyArtifactOnJavaConfigurations(
             Project project, TaskProvider<ShadowJar> shadowJarProvider) {
 
         Stream.of(JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME, JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME)
@@ -254,5 +256,11 @@ public class ShadowJarPlugin implements Plugin<Project> {
                     conf.getOutgoing().getArtifacts().clear();
                     conf.getOutgoing().artifact(shadowJarProvider);
                 }));
+    }
+
+    private static void dependOnJarTaskInOrderToTriggerTasksAddingManifestAttributes(
+            Project project, TaskProvider<ShadowJar> shadowJarProvider) {
+        shadowJarProvider.configure(shadowJar ->
+                shadowJar.dependsOn(project.getTasks().withType(Jar.class).named("jar")));
     }
 }

--- a/src/test/groovy/com/palantir/gradle/shadowjar/ShadowJarPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/shadowjar/ShadowJarPluginIntegrationSpec.groovy
@@ -354,6 +354,28 @@ class ShadowJarPluginIntegrationSpec extends IntegrationSpec {
         assert new File(projectDir, 'build/libs/asd-fgh-2-thin.jar').exists()
     }
 
+    def 'shadowJar should contain manifest entries added to thin jar in tasks'() {
+        buildFile << '''
+            dependencies {
+                shadeTransitively 'org.apiguardian:apiguardian-api:1.1.0'
+            }
+            
+            task addManifestItem {
+                doFirst {
+                    jar.manifest.attributes('Foo': 'Bar')
+                }
+            }
+            
+            jar.dependsOn addManifestItem
+        '''
+
+        when:
+        runTasksAndCheckSuccess('publishNebulaPublicationToTestRepoRepository')
+
+        then:
+        shadowJarFile().manifest.mainAttributes.get('Foo') == 'Bar'
+    }
+
     @CompileStatic
     private Set<String> jarEntryNames() {
         JarFile shadowJar = shadowJarFile()

--- a/src/test/groovy/com/palantir/gradle/shadowjar/ShadowJarPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/shadowjar/ShadowJarPluginIntegrationSpec.groovy
@@ -360,6 +360,7 @@ class ShadowJarPluginIntegrationSpec extends IntegrationSpec {
                 shadeTransitively 'org.apiguardian:apiguardian-api:1.1.0'
             }
             
+            // This replicates what the 'com.palantir.sls-recommended-dependencies' plugin does
             task addManifestItem {
                 doFirst {
                     jar.manifest.attributes('Foo': 'Bar')
@@ -373,7 +374,7 @@ class ShadowJarPluginIntegrationSpec extends IntegrationSpec {
         runTasksAndCheckSuccess('publishNebulaPublicationToTestRepoRepository')
 
         then:
-        shadowJarFile().manifest.mainAttributes.get('Foo') == 'Bar'
+        shadowJarFile().manifest.mainAttributes.getValue('Foo') == 'Bar'
     }
 
     @CompileStatic


### PR DESCRIPTION
## Before this PR
If a task adds manifest attributes to a jar (for example [ConfigureProductDependenciesTask in the `com.palantir.sls-recommended-dependencies` plugin](https://github.com/palantir/sls-packaging/blob/73c579daec0f5ae571b4b4a94011c74e983000f1/gradle-recommended-product-dependencies/src/main/java/com/palantir/gradle/dist/ConfigureProductDependenciesTask.java#L38)), currently running `shadowJar` will not pick them up, despite the [default beahviour of inheriting manifests](https://imperceptiblethoughts.com/shadow/configuration/#configuring-the-jar-manifest), as these tasks are normally added as dependencies on `jar` which `shadowJar` does not currently trigger.

## After this PR
==COMMIT_MSG==
`shadowJar` now depends on the `jar` task in order to trigger tasks like `configureProductDependencies` from `com.palantir.sls-recommended-dependencies` which modify the `jar` manifest, so that these `manifest` changes are inherited by default in `shadowJar`.
==COMMIT_MSG==

## Possible downsides?
We now have to run the jar task, which means we need to zip up a few jar files. This should not be expensive, especially compared to the cost of relocating classes in the shadow jar.
