### PR TITLE
Avoid empty lines in the middle of the manifest when shading a multi-release jar

### DIFF
--- a/changelog/@unreleased/pr-77.v2.yml
+++ b/changelog/@unreleased/pr-77.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Previously, projects that shaded multi-release jars may have had an
+    empty line in the middle of their manifest, which would prevent the manifest from
+    being parsed. This has been removed.
+  links:
+  - https://github.com/palantir/gradle-shadow-jar/pull/77

--- a/src/main/groovy/com/palantir/gradle/shadowjar/ComposableManifestAppenderTransformer.groovy
+++ b/src/main/groovy/com/palantir/gradle/shadowjar/ComposableManifestAppenderTransformer.groovy
@@ -1,0 +1,89 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Change: Different package, added imports
+package com.palantir.gradle.shadowjar
+
+import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.TransformerContext
+import shadow.org.apache.tools.zip.ZipOutputStream
+import shadow.org.apache.tools.zip.ZipEntry
+import shadow.org.codehaus.plexus.util.IOUtil
+import org.gradle.api.file.FileTreeElement
+
+import static java.nio.charset.StandardCharsets.*
+import static java.util.jar.JarFile.*
+
+// Originally taken from https://github.com/johnrengelman/shadow/blob/6.1.0/src/main/groovy/com/github/jengelman/
+// gradle/plugins/shadow/transformers/ManifestAppenderTransformer.groovy
+class ComposableManifestAppenderTransformer implements Transformer {
+    private static final byte[] EOL = "\r\n".getBytes(UTF_8)
+    private static final byte[] SEPARATOR = ": ".getBytes(UTF_8)
+
+    private byte[] manifestContents = []
+    private final List<Tuple2<String, ? extends Comparable<?>>> attributes = []
+
+    List<Tuple2<String, ? extends Comparable<?>>> getAttributes() { attributes }
+
+    ComposableManifestAppenderTransformer append(String name, Comparable<?> value) {
+        attributes.add(new Tuple2<String, ? extends Comparable<?>>(name, value))
+        this
+    }
+
+    @Override
+    boolean canTransformResource(FileTreeElement element) {
+        MANIFEST_NAME.equalsIgnoreCase(element.relativePath.pathString)
+    }
+
+    @Override
+    void transform(TransformerContext context) {
+        if (manifestContents.length == 0) {
+            manifestContents = IOUtil.toByteArray(context.is)
+            IOUtil.close(context.is)
+        }
+    }
+
+    @Override
+    boolean hasTransformedResource() {
+        !attributes.isEmpty()
+    }
+
+    @Override
+    void modifyOutputStream(ZipOutputStream os, boolean preserveFileTimestamps) {
+        ZipEntry entry = new ZipEntry(MANIFEST_NAME)
+        entry.time = TransformerContext.getEntryTimestamp(preserveFileTimestamps, entry.time)
+        os.putNextEntry(entry)
+        // Change: Trim existing file contents and add a single trailing newline
+        os.write(trimWhitespace(manifestContents))
+        os.write(EOL)
+
+        if (!attributes.isEmpty()) {
+            for (attribute in attributes) {
+                os.write(attribute.first.getBytes(UTF_8))
+                os.write(SEPARATOR)
+                os.write(attribute.second.toString().getBytes(UTF_8))
+                os.write(EOL)
+            }
+            os.write(EOL)
+            attributes.clear()
+        }
+    }
+
+    // Change: New method
+    static byte[] trimWhitespace(byte[] contents) {
+        return new String(contents, UTF_8).trim().getBytes(UTF_8);
+    }
+}

--- a/src/main/groovy/com/palantir/gradle/shadowjar/ShadowJarConfigurationTask.java
+++ b/src/main/groovy/com/palantir/gradle/shadowjar/ShadowJarConfigurationTask.java
@@ -21,7 +21,6 @@ import com.github.jengelman.gradle.plugins.shadow.relocation.RelocateClassContex
 import com.github.jengelman.gradle.plugins.shadow.relocation.RelocatePathContext;
 import com.github.jengelman.gradle.plugins.shadow.relocation.SimpleRelocator;
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar;
-import com.github.jengelman.gradle.plugins.shadow.transformers.ManifestAppenderTransformer;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
@@ -124,7 +123,7 @@ public abstract class ShadowJarConfigurationTask extends DefaultTask {
 
         if (!multiReleaseStuff.isEmpty()) {
             try {
-                shadowJarTask.transform(ManifestAppenderTransformer.class, transformer -> {
+                shadowJarTask.transform(ComposableManifestAppenderTransformer.class, transformer -> {
                     // JEP 238 requires this manifest entry
                     transformer.append("Multi-Release", true);
                 });

--- a/src/test/groovy/com/palantir/gradle/shadowjar/ShadowJarPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/shadowjar/ShadowJarPluginIntegrationSpec.groovy
@@ -190,6 +190,9 @@ class ShadowJarPluginIntegrationSpec extends IntegrationSpec {
         assert shadowJarFile().isMultiRelease() ?:
                 "The jar manifest must include 'Multi-Release: true', but was '" +
                         file("build/extractForAssertions/META-INF/MANIFEST.MF").text + "'"
+
+        // What is of interest here is that this does not throw an exception
+        shadowJarFile().getManifest()
     }
 
     def 'should shade known logging implementations iff it is placed in shadeTransitively directly'() {

--- a/versions.props
+++ b/versions.props
@@ -1,4 +1,5 @@
 com.github.jengelman.gradle.plugins:shadow = 6.1.0
+org.apache.ant:ant = 1.9.7
 org.immutables:value = 2.8.8
 com.google.guava:guava = 30.0-jre
 

--- a/versions.props
+++ b/versions.props
@@ -1,5 +1,4 @@
 com.github.jengelman.gradle.plugins:shadow = 6.1.0
-org.apache.ant:ant = 1.9.7
 org.immutables:value = 2.8.8
 com.google.guava:guava = 30.0-jre
 


### PR DESCRIPTION
## Before this PR
#76 was a problem

## After this PR
#76 should be fixed.

## Possible downsides?
Is there a case I've missed out on / where the blank lines I'm removing lose semantic information?

The test I've added is a bit weak.