### PR TITLE
Improvement: Do not shade safe logger

### DIFF
--- a/changelog/@unreleased/pr-155.v2.yml
+++ b/changelog/@unreleased/pr-155.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Do not shade safe logger
+  links:
+  - https://github.com/palantir/gradle-shadow-jar/pull/155

--- a/src/main/groovy/com/palantir/gradle/shadowjar/ShadowJarPlugin.java
+++ b/src/main/groovy/com/palantir/gradle/shadowjar/ShadowJarPlugin.java
@@ -47,6 +47,7 @@ public class ShadowJarPlugin implements Plugin<Project> {
             groupOf("commons-logging"),
             groupOf("log4j"),
             groupOf("org.apache.logging.log4j"),
+            groupOf("com.palantir.logsafe.logger"),
             groupOf("org.springframework").and(artifactOf("spring-jcl")));
 
     private static Predicate<ResolvedDependency> groupOf(String group) {


### PR DESCRIPTION
## Before this PR
Users could inadvertently shade the safe-logger packages which would end up breaking logging

## After this PR
==COMMIT_MSG==
Do not shade safe logger
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
