### PR TITLE
ServiceLoader service providers are left in place

### DIFF
--- a/changelog/@unreleased/pr-362.v2.yml
+++ b/changelog/@unreleased/pr-362.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: ServiceLoader service providers within shaded modules work as expected
+  links:
+  - https://github.com/palantir/gradle-shadow-jar/pull/362


### PR DESCRIPTION
==COMMIT_MSG==
ServiceLoader service providers within shaded modules work as expected
==COMMIT_MSG==

Previously these were renamed to `shadow/com/palantir/name/META-INF/services/shadow.com.palantir.name.Fqcn` unexpectedly.