### PR TITLE
Ban com.palantir.sls.logging:sls-logging-log4j-slf4j from shading

### DIFF
--- a/changelog/@unreleased/pr-509.v2.yml
+++ b/changelog/@unreleased/pr-509.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Ban com.palantir.sls.logging:sls-logging-log4j-slf4j from shading.
+  links:
+  - https://github.com/palantir/gradle-shadow-jar/pull/509

--- a/src/main/groovy/com/palantir/gradle/shadowjar/ShadowJarPlugin.java
+++ b/src/main/groovy/com/palantir/gradle/shadowjar/ShadowJarPlugin.java
@@ -48,6 +48,7 @@ public class ShadowJarPlugin implements Plugin<Project> {
             groupOf("log4j"),
             groupOf("org.apache.logging.log4j"),
             groupOf("com.palantir.safe-logging").and(artifactOf("safe-logging")),
+            groupOf("com.palantir.sls.logging").and(artifactOf("sls-logging-log4j-slf4j")),
             groupOf("com.palantir.tracing").and(artifactOf("tracing").or(artifactOf("tracing-api"))),
             groupOf("com.palantir.tritium").and(artifactOf("tritium-registry")),
             groupOf("org.springframework").and(artifactOf("spring-jcl")));


### PR DESCRIPTION
## Before this PR
We were hitting issues with com.palantir.sls.logging.log4j.slf4j.SlsLog4jSlf4jLoggerFactory being shaded even though logging libraries should be banned from shading.

## After this PR
Ban com.palantir.sls.logging:sls-logging-log4j-slf4j from being shaded.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

