### PR TITLE
don't require strict order or plugin application

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         classpath 'com.palantir.jakartapackagealignment:jakarta-package-alignment:0.6.0'
         classpath 'com.palantir.gradle.jdks:gradle-jdks:0.69.0'
         classpath 'com.palantir.gradle.jdkslatest:gradle-jdks-latest:0.24.0'
-        classpath 'com.palantir.gradle.plugintesting:gradle-plugin-testing:0.39.0'
+        classpath 'com.palantir.gradle.plugintesting:gradle-plugin-testing:0.41.0'
         classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.27.0'
         classpath 'com.palantir.gradle.failure-reports:gradle-failure-reports:1.18.0'
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:2.83.0'

--- a/src/main/java/com/palantir/gradle/shadowjar/ShadowJarPlugin.java
+++ b/src/main/java/com/palantir/gradle/shadowjar/ShadowJarPlugin.java
@@ -75,10 +75,12 @@ public class ShadowJarPlugin implements Plugin<Project> {
                     "You must be using Gradle 7 or above to use the com.palantir.shadow-jar plugin");
         }
 
-        if (!project.getRootProject().getPlugins().hasPlugin("com.palantir.consistent-versions")) {
-            throw new IllegalStateException(
-                    "You must apply com.palantir.consistent-versions to use the com.palantir.shadow-jar plugin");
-        }
+        project.afterEvaluate(_p -> {
+            if (!project.getRootProject().getPlugins().hasPlugin("com.palantir.consistent-versions")) {
+                throw new IllegalStateException(
+                        "You must apply com.palantir.consistent-versions to use the com.palantir.shadow-jar plugin");
+            }
+        });
 
         project.getPluginManager().apply(JavaPlugin.class);
         project.getPluginManager().apply(ShadowPlugin.class);
@@ -312,14 +314,18 @@ public class ShadowJarPlugin implements Plugin<Project> {
     }
 
     private static void lockConfiguration(Project project, NamedDomainObjectProvider<Configuration> configuration) {
-        VersionsLockExtension versionsLock = project.getExtensions().getByType(VersionsLockExtension.class);
-        versionsLock.production(scope -> scope.from(configuration.getName()));
+        project.getPluginManager().withPlugin("com.palantir.consistent-versions", _plugin -> {
+            VersionsLockExtension versionsLock = project.getExtensions().getByType(VersionsLockExtension.class);
+            versionsLock.production(scope -> scope.from(configuration.getName()));
+        });
     }
 
     private static void excludeConfigurationFromVersionsPropsInjection(
             Project project, NamedDomainObjectProvider<Configuration> configuration) {
-        VersionRecommendationsExtension versionRecommendations =
-                project.getRootProject().getExtensions().getByType(VersionRecommendationsExtension.class);
-        versionRecommendations.excludeConfigurations(configuration.getName());
+        project.getRootProject().getPluginManager().withPlugin("com.palantir.consistent-versions", _plugin -> {
+            VersionRecommendationsExtension versionRecommendations =
+                    project.getRootProject().getExtensions().getByType(VersionRecommendationsExtension.class);
+            versionRecommendations.excludeConfigurations(configuration.getName());
+        });
     }
 }

--- a/src/test/java/com/palantir/gradle/shadowjar/ShadowJarPluginIntegrationTest.java
+++ b/src/test/java/com/palantir/gradle/shadowjar/ShadowJarPluginIntegrationTest.java
@@ -29,6 +29,7 @@ import com.google.common.io.CharStreams;
 import com.palantir.gradle.testing.execution.GradleInvoker;
 import com.palantir.gradle.testing.execution.InvocationResult;
 import com.palantir.gradle.testing.execution.TaskOutcome;
+import com.palantir.gradle.testing.junit.DisabledConfigurationCache;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.maven.MavenArtifact;
 import com.palantir.gradle.testing.maven.MavenRepo;
@@ -558,6 +559,19 @@ class ShadowJarPluginIntegrationTest {
         InvocationResult rerun = runTasksAndCheckSuccess(gradle, "--build-cache", "shadowJar");
 
         assertThat(rerun).task(":shadowJar").outcome().isEqualTo(TaskOutcome.FROM_CACHE);
+    }
+
+    @Test
+    @DisabledConfigurationCache(reason = "Configuration-time failure: both initial and dry-run will fail")
+    void should_fail_when_consistent_versions_plugin_is_not_applied(GradleInvoker gradle, RootProject project) {
+        project.buildGradle().createEmpty();
+        project.buildGradle().plugins().add("com.palantir.shadow-jar");
+
+        InvocationResult result = gradle.withArgs("help").buildsWithFailure();
+
+        assertThat(result)
+                .output()
+                .contains("You must apply com.palantir.consistent-versions to use the com.palantir.shadow-jar plugin");
     }
 
     private Set<String> jarEntryNames(RootProject project) {

--- a/src/test/java/com/palantir/gradle/shadowjar/ShadowJarPluginIntegrationTest.java
+++ b/src/test/java/com/palantir/gradle/shadowjar/ShadowJarPluginIntegrationTest.java
@@ -29,7 +29,6 @@ import com.google.common.io.CharStreams;
 import com.palantir.gradle.testing.execution.GradleInvoker;
 import com.palantir.gradle.testing.execution.InvocationResult;
 import com.palantir.gradle.testing.execution.TaskOutcome;
-import com.palantir.gradle.testing.junit.DisabledConfigurationCache;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.maven.MavenArtifact;
 import com.palantir.gradle.testing.maven.MavenRepo;
@@ -562,7 +561,6 @@ class ShadowJarPluginIntegrationTest {
     }
 
     @Test
-    @DisabledConfigurationCache(reason = "Expected configuration-time failure: both initial and dry-run will fail")
     void should_fail_when_consistent_versions_plugin_is_not_applied(GradleInvoker gradle, RootProject project) {
         project.buildGradle().createEmpty();
         project.buildGradle().plugins().add("com.palantir.shadow-jar");

--- a/src/test/java/com/palantir/gradle/shadowjar/ShadowJarPluginIntegrationTest.java
+++ b/src/test/java/com/palantir/gradle/shadowjar/ShadowJarPluginIntegrationTest.java
@@ -562,7 +562,7 @@ class ShadowJarPluginIntegrationTest {
     }
 
     @Test
-    @DisabledConfigurationCache(reason = "Configuration-time failure: both initial and dry-run will fail")
+    @DisabledConfigurationCache(reason = "Expected configuration-time failure: both initial and dry-run will fail")
     void should_fail_when_consistent_versions_plugin_is_not_applied(GradleInvoker gradle, RootProject project) {
         project.buildGradle().createEmpty();
         project.buildGradle().plugins().add("com.palantir.shadow-jar");

--- a/versions.lock
+++ b/versions.lock
@@ -112,11 +112,13 @@ com.netflix.nebula:nebula-publishing-plugin:17.2.1 (1 constraints: 3d05513b)
 
 com.netflix.nebula:nebula-test:10.6.2 (1 constraints: 9c18268f)
 
-com.palantir.gradle.plugintesting:configuration-cache-spec:0.39.0 (1 constraints: 3e05463b)
+com.palantir.gradle.plugintesting:configuration-cache-spec:0.41.0 (1 constraints: 3705323b)
 
-com.palantir.gradle.plugintesting:gradle-plugin-testing-junit:0.39.0 (1 constraints: 3e05463b)
+com.palantir.gradle.plugintesting:discover-tests-cli:0.41.0 (1 constraints: 3705323b)
 
-com.palantir.gradle.plugintesting:plugin-testing-core:0.39.0 (1 constraints: 3e05463b)
+com.palantir.gradle.plugintesting:gradle-plugin-testing-junit:0.41.0 (1 constraints: 3705323b)
+
+com.palantir.gradle.plugintesting:plugin-testing-core:0.41.0 (1 constraints: 3705323b)
 
 com.palantir.safe-logging:logger:3.9.0 (1 constraints: a40c4f09)
 
@@ -143,6 +145,8 @@ commons-codec:commons-codec:1.9 (1 constraints: c90f9e71)
 commons-logging:commons-logging:1.2 (1 constraints: c20f9771)
 
 de.regnis.q.sequence:sequence-library:1.0.3 (1 constraints: 8f0c0c02)
+
+info.picocli:picocli:4.7.7 (1 constraints: 2816dcdd)
 
 io.dropwizard.metrics:metrics-core:4.2.37 (1 constraints: ca1057b6)
 
@@ -190,7 +194,7 @@ org.junit.platform:junit-platform-commons:6.0.1 (2 constraints: d520474a)
 
 org.junit.platform:junit-platform-engine:6.0.1 (4 constraints: 9e40c7e2)
 
-org.junit.platform:junit-platform-launcher:6.0.1 (1 constraints: 09050a36)
+org.junit.platform:junit-platform-launcher:6.0.1 (2 constraints: 571b2362)
 
 org.junit.vintage:junit-vintage-engine:6.0.1 (1 constraints: 09050a36)
 


### PR DESCRIPTION
## Before this PR
GCV had to be applied before the shadow plugin 
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
Now you just have to apply GCV the order does not matter
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

